### PR TITLE
update setup.py to include operator submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version='0.5.0',
     author='onesuper',
     author_email='onesuperclark@gmail.com',
-    packages=['pandasticsearch'],
+    packages=['pandasticsearch', 'pandasticsearch.operators'],
     url='http://pypi.python.org/pypi/pandasticsearch/',
     license='MIT',
     description='A Pandastic Elasticsearch client for data analyzing.',


### PR DESCRIPTION
Current build is not working, as pandasticsearch.operator is not included in installation,
and operations like `from pandasticsearch import DataFrame` raises `ModuleNotFoundError`

This commit fixes this bug.