### PR TITLE
Fix value not set in Agg.explain_result

### DIFF
--- a/pandasticsearch/queries.py
+++ b/pandasticsearch/queries.py
@@ -165,7 +165,7 @@ class Agg(Query):
         self._indexes = []
         for t in tuples:
             _, index, row = t
-            self.append(row)
+            self._values.append(row)
             if len(index) > 0:
                 self._indexes.append(index)
 


### PR DESCRIPTION
In explain_result() of Agg class, _values are not set properly, which affects other methods such as to_pandas().

This PR fixes this bug.