### PR TITLE
Fix mappings breaking changes and related improvements

### DIFF
--- a/pandasticsearch/dataframe.py
+++ b/pandasticsearch/dataframe.py
@@ -138,7 +138,7 @@ class DataFrame(object):
                 raise TypeError('Column does not exist: [{0}]'.format(item))
             return Column(item)
         elif isinstance(item, BooleanFilter):
-            self._filter = item.build()
+            self._filter = item
             return self
         else:
             raise TypeError('Unsupported expr: [{0}]'.format(item))

--- a/pandasticsearch/dataframe.py
+++ b/pandasticsearch/dataframe.py
@@ -434,10 +434,18 @@ class DataFrame(object):
 
         sys.stdout.write('{0}\n'.format(self._index))
         index = list(self._mapping.values())[0]  # {'index': {}}
-        for typ, properties in six.iteritems(index['mappings']):
-            sys.stdout.write('|--{0}\n'.format(typ))
-            for k, v in six.iteritems(properties['properties']):
-                sys.stdout.write('  |--{0}: {1}\n'.format(k, v))
+        schema = self.resolve_schema(index['mappings']['properties'])
+        sys.stdout.write(schema)
+
+    def resolve_schema(self, json_prop, res_schema="", depth=1):
+        for field in json_prop:
+            if "properties" in json_prop[field]:
+                res_schema += f"{'  '*depth}|--{field}:\n"
+                res_schema = self.resolve_schema(json_prop[field]["properties"],
+                                                 res_schema, depth=depth+1)
+            else:
+                res_schema += f"{'  ' * depth}|--{field}: {json_prop[field]}\n"
+        return res_schema
 
     def _build_query(self):
         query = dict()
@@ -488,15 +496,30 @@ class DataFrame(object):
 
     @classmethod
     def _get_cols(cls, mapping):
-        cols = []
-        index = list(mapping.values())[0]  # {'index': {}}
-        for _, properties in six.iteritems(index['mappings']):
-            for k, _ in six.iteritems(properties['properties']):
-                cols.append(k)
+        index = list(mapping.keys())[0]
+        cols = cls.get_mappings(mapping, index)
 
         if len(cols) == 0:
             raise Exception('0 columns found in mapping')
         return cols
+
+    @classmethod
+    def resolve_mappings(cls, json_map):
+        prop = []
+        for field in json_map:
+            nested_props = []
+            if "properties" in json_map[field]:
+                nested_props = cls.resolve_mappings(json_map[field]["properties"])
+            if len(nested_props) == 0:
+                prop.append(field)
+            else:
+                for nested_prop in nested_props:
+                    prop.append(f"{field}.{nested_prop}")
+        return prop
+
+    @classmethod
+    def get_mappings(cls, json_map, index_name):
+        return cls.resolve_mappings(json_map[index_name]["mappings"]["properties"])
 
     @classmethod
     def _get_doc_type(cls, mapping):

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -9,8 +9,30 @@ from pandasticsearch.operators import *
 @patch('pandasticsearch.client.urllib.request.urlopen')
 def create_df_from_es(mock_urlopen):
     response = Mock()
-    dic = {"index": {"mappings": {"doc_type": {"properties": {"a": {"type": "integer"},
-                                                              "b": {"type": "integer"}}}}}}
+    dic = {
+      "metricbeat-7.0.0-qa": {
+        "mappings": {
+          "_meta": {
+            "beat": "metricbeat",
+            "version": "7.0.0"
+          },
+          "date_detection": False,
+          "properties": {
+            "a": {
+              "type": "integer"
+            },
+            "b": {
+              "type": "integer"
+            },
+            "c": {"properties": {
+                "d": {"type": "keyword", "ignore_above": 1024},
+                "e": {"type": "keyword", "ignore_above": 1024}
+              }
+            }
+          }
+        }
+      }
+    }
     response.read.return_value = json.dumps(dic).encode("utf-8")
     mock_urlopen.return_value = response
     return DataFrame.from_es(url="http://localhost:9200", index='xxx')
@@ -34,7 +56,7 @@ class TestDataFrame(unittest.TestCase):
 
     def test_columns(self):
         df = create_df_from_es()
-        self.assertEqual(df.columns, ['a', 'b'])
+        self.assertEqual(df.columns, ['a', 'b', 'c.d', 'c.e'])
 
     def test_init(self):
         df = create_df_from_es()

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -47,7 +47,7 @@ class TestDataFrame(unittest.TestCase):
         expr = df['a'] > 2
         self.assertTrue(isinstance(expr, BooleanFilter))
         self.assertTrue(isinstance(df[expr], DataFrame))
-        self.assertEqual(df[expr]._filter, {'range': {'a': {'gt': 2}}})
+        self.assertEqual(df[expr]._filter.build(), {'range': {'a': {'gt': 2}}})
 
     def test_getattr(self):
         df = create_df_from_es()


### PR DESCRIPTION
## Please, take care that this changes are not compatible with ES < 7.x. A new tag or branch for this version should probably be created


This fixes #29 and few other things

In detail:

* support for 7.x mappings
* nested fields are now supported
* fixed print schema
* df.show() can now also retrieve data for the nested fields
* fixed alternative filter syntax eg. df[df.a > 2] which was returning the following error `TypeError: unsupported operand type(s) for &: 'dict' and 'Greater'`
* added/changed 2 unit tests