### PR TITLE
Fix for multiple nested filters.

### DIFF
--- a/pandasticsearch/operators/filter.py
+++ b/pandasticsearch/operators/filter.py
@@ -9,7 +9,7 @@ class BooleanFilter(object):
     def __and__(self, x):
         # Combine results
         if isinstance(self, AndFilter):
-            self.subtree['must'].append(x.subtree)
+            self.subtree['must'].append(x.build())
             return self
         elif isinstance(x, AndFilter):
             x.subtree['must'].append(self.subtree)
@@ -19,7 +19,7 @@ class BooleanFilter(object):
     def __or__(self, x):
         # Combine results
         if isinstance(self, OrFilter):
-            self.subtree['should'].append(x.subtree)
+            self.subtree['should'].append(x.build())
             return self
         elif isinstance(x, OrFilter):
             x.subtree['should'].append(self.subtree)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -96,6 +96,23 @@ class TestOperators(unittest.TestCase):
                 }
             })
 
+    def test_and_filter2a(self):
+        exp = GreaterEqual('a', 2) & Less('b', 3) & (Equal('c', 4) & Equal('d', 5))
+        self.assertEqual(
+            exp.build(),
+            {
+                'bool': {
+                    'must': [
+                        {'range': {'a': {'gte': 2}}},
+                        {'range': {'b': {'lt': 3}}},
+                        {'bool': {'must': [
+                            {'term': {'c': 4}},
+                            {'term': {'d': 5}},
+                        ]}},
+                    ]
+                }
+            })
+
     def test_and_filter3(self):
         exp = GreaterEqual('a', 2) & (Less('b', 3) & Equal('c', 4))
         self.assertEqual(
@@ -133,6 +150,23 @@ class TestOperators(unittest.TestCase):
                         {'range': {'a': {'gte': 2}}},
                         {'range': {'b': {'lt': 3}}},
                         {'term': {'c': 4}}
+                    ]
+                }
+            })
+
+    def test_or_filter2a(self):
+        exp = GreaterEqual('a', 2) | Less('b', 3) | (Equal('c', 4) & Equal('d', 5))
+        self.assertEqual(
+            exp.build(),
+            {
+                'bool': {
+                    'should': [
+                        {'range': {'a': {'gte': 2}}},
+                        {'range': {'b': {'lt': 3}}},
+                        {'bool': {'must': [
+                            {'term': {'c': 4}},
+                            {'term': {'d': 5}},
+                        ]}},
                     ]
                 }
             })


### PR DESCRIPTION
added test_and_filter2a
added test_or_filter2a

both now work properly. whereas before they
gave a malformed query error.