### PR TITLE
Handle buckets without key or key_as_string in dict

### DIFF
--- a/pandasticsearch/queries.py
+++ b/pandasticsearch/queries.py
@@ -251,8 +251,11 @@ class Agg(Query):
 
                         if 'key_as_string' in sub_bucket:
                             key = sub_bucket['key_as_string']
-                        else:
+                        elif 'key' in sub_bucket:
                             key = sub_bucket['key']
+                        else:
+                            key = sub_bucket
+                            sub_bucket = v['buckets'][sub_bucket]
                         for x in Agg._process_agg(sub_bucket,
                                                   indexes + (key,),
                                                   names + (k,)):


### PR DESCRIPTION
Added functionality to allow for sub buckets that don't have key or key_as_string fields but are just a dict object that has a doc_count or value in it. 

Example Agg search:


Example bucket this is needed for:

`"aggregations" : {
    "L1" : {
      "buckets" : [
        {
          "key" : "L1.1",
          "doc_count" : 10,
          "L2" : {
            "doc_count_error_upper_bound" : 0,
            "sum_other_doc_count" : 0,
            "buckets" : [
              {
                "key" : "L1.1L2.1",
                "doc_count" : 20,
                "L3" : {
                  "buckets" : {
                    "L1.1L2.1L3.1" : {
                      "doc_count" : 15
                    }
                  }
                }
              },
              {
                "key" : "L1.1L2.1L3.2",
                "doc_count" : 5,
                "L3" : {
                  "buckets" : {
                    "L1.1L2.1L3.2L4.1" : {
                      "doc_count" : 8
                    }
                  }
                }
              }
            ]
          }
        },`